### PR TITLE
First version of the ROS 1 driver: single radar, non-accumulated point clouds publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,190 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+# Include support for ExternalProject_Add
+include(ExternalProject)
+
+project(provizio_radar_api_ros)
+
+add_compile_options(-std=c++14)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  sensor_msgs
+)
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  #INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp sensor_msgs
+)
+
+###########
+## Build ##
+###########
+
+# Provizio Core Radar API
+set(PROVIZIO_RADAR_CORE_API_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/provizio_radar_api_core_build")
+set(PROVIZIO_RADAR_CORE_API_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/provizio_radar_api_core")
+set(PROVIZIO_RADAR_CORE_API_PREFIX "${CMAKE_CURRENT_BINARY_DIR}")
+set(PROVIZIO_RADAR_CORE_API_GITHUB_PROJECT "provizio/provizio_radar_api_core") # Or your own fork
+set(PROVIZIO_RADAR_CORE_API_GITHUB_BRANCH "v22.11.17") # Or a specific tag you'd like to use
+set(PROVIZIO_RADAR_CORE_API_INSTALL_DIR "${PROVIZIO_RADAR_CORE_API_BINARY_DIR}/install")
+ExternalProject_Add(libprovizio_radar_api_core
+  GIT_REPOSITORY "https://github.com/${PROVIZIO_RADAR_CORE_API_GITHUB_PROJECT}.git" # or "git@github.com:${PROVIZIO_RADAR_CORE_API_GITHUB_PROJECT}.git" for ssh access, or your custom repo
+  GIT_TAG "${PROVIZIO_RADAR_CORE_API_GITHUB_BRANCH}"
+  PREFIX "${PROVIZIO_RADAR_CORE_API_PREFIX}"
+  SOURCE_DIR "${PROVIZIO_RADAR_CORE_API_SOURCE_DIR}"
+  BINARY_DIR "${PROVIZIO_RADAR_CORE_API_BINARY_DIR}"
+  CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" "-DCMAKE_INSTALL_PREFIX=${PROVIZIO_RADAR_CORE_API_INSTALL_DIR}" "-DENABLE_CHECK_FORMAT=OFF" "-DBUILD_TESTING=OFF"
+)
+link_directories("${PROVIZIO_RADAR_CORE_API_INSTALL_DIR}/lib")
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+add_executable(${PROJECT_NAME}_node src/provizio_radar_api_ros_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+add_dependencies(${PROJECT_NAME}_node
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+  libprovizio_radar_api_core # Provizio Core API
+)
+
+# Provizio Core API headers
+target_include_directories(${PROJECT_NAME}_node SYSTEM PUBLIC "${PROVIZIO_RADAR_CORE_API_INSTALL_DIR}/include")
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME}_node
+  ${catkin_LIBRARIES}
+  provizio_radar_api_core
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executables for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_provizio_radar_api_ros.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# provizio_radar_api_ros
+
+ROS 1 Driver for Provizio radars.
+
+## Provided Functionality
+
+- Supports a single radar on the network.
+- Publishes live, non-accumulated point clouds.
+
+## Topics
+
+### /provizio_radar_point_cloud
+
+Live non-accumulated point clouds as [http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/PointCloud2.html](sensor_msgs/PointCloud2).
+
+Point fields present:
+
+- `x`: Forward, radar relative, meters, float (32 bit)
+- `y`: Left, radar relative, meters, float (32 bit)
+- `z`: Up, radar relative, meters, float (32 bit)
+- `radar_relative_radial_velocity`: Forward, radar relative, meters/second, float (32 bit)
+- `signal_to_noise_ratio`: float (32 bit)
+- `ground_relative_radial_velocity`: Forward, ground relative, meters/second, float (32 bit). May be a valid value or NaN depending on a radar configuration.
+
+## Native API
+
+The complete native API written in C can be [found here](https://github.com/provizio/provizio_radar_api_core).
+
+## License
+
+Open-source as Apache License 2.0 (see [LICENSE](LICENSE))

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>provizio_radar_api_ros</name>
+  <version>23.01.19</version>
+  <description>ROS 1 Driver for Provizio radars</description>
+
+  <maintainer email="contact@provizio.ai">Provizio</maintainer>
+
+  <license>Apache 2.0 License</license>
+
+  <url type="website">https://provizio.ai/</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+</package>

--- a/src/provizio_radar_api_ros_node.cpp
+++ b/src/provizio_radar_api_ros_node.cpp
@@ -1,0 +1,169 @@
+// Copyright 2022 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <inttypes.h>
+
+#include "ros/ros.h"
+#include "sensor_msgs/PointCloud2.h"
+
+#include "provizio/radar_api/core.h"
+
+namespace
+{
+    constexpr const char *topic_name = "/provizio_radar_point_cloud";
+    constexpr std::uint64_t receive_timeout_ns = 100000000; // 0.1s
+
+    std::size_t point_clouds_sent = 0;
+    std::size_t points_sent = 0;
+
+    // Checks if the host is big endian
+    constexpr bool is_host_big_endian()
+    {
+        union
+        {
+            uint32_t as_int;
+            char as_chars[4];
+        } testint = {0x01020304};
+
+        return testint.as_chars[0] == 1;
+    }
+
+    // Gets invoked every time a complete or incomplete (in case of lost packets) point cloud is received
+    void point_cloud_callback(const provizio_radar_point_cloud *point_cloud,
+                              struct provizio_radar_point_cloud_api_context *context)
+    {
+        // As defined in http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/PointField.html
+        constexpr std::uint8_t float_field_type = 7;
+        constexpr std::size_t num_fields_per_point = 6;
+        constexpr std::size_t field_x = 0;
+        constexpr std::size_t field_y = 1;
+        constexpr std::size_t field_z = 2;
+        constexpr std::size_t field_radar_relative_radial_velocity = 3;
+        constexpr std::size_t field_signal_to_noise_ratio = 4;
+        constexpr std::size_t field_ground_relative_radial_velocity = 5; // May be valid or NaN, depending on radar configuration
+
+        // Convert provizio_radar_point_cloud to sensor_msgs::PointCloud2
+        sensor_msgs::PointCloud2 ros_point_cloud;
+        ros_point_cloud.header.seq = static_cast<std::uint32_t>(point_clouds_sent++);
+        ros_point_cloud.header.stamp.fromNSec(point_cloud->timestamp);
+        ros_point_cloud.header.frame_id = "provizio_radar_" + std::to_string(point_cloud->radar_position_id); // Defines a reference frame, not a frame number
+        ros_point_cloud.height = 1;
+        ros_point_cloud.width = point_cloud->num_points_received;
+        ros_point_cloud.fields.resize(num_fields_per_point);
+        ros_point_cloud.fields[field_x].name = "x";
+        ros_point_cloud.fields[field_x].offset = offsetof(provizio_radar_point, x_meters);
+        ros_point_cloud.fields[field_x].datatype = float_field_type;
+        ros_point_cloud.fields[field_x].count = 1;
+        ros_point_cloud.fields[field_y].name = "y";
+        ros_point_cloud.fields[field_y].offset = offsetof(provizio_radar_point, y_meters);
+        ros_point_cloud.fields[field_y].datatype = float_field_type;
+        ros_point_cloud.fields[field_y].count = 1;
+        ros_point_cloud.fields[field_z].name = "z";
+        ros_point_cloud.fields[field_z].offset = offsetof(provizio_radar_point, z_meters);
+        ros_point_cloud.fields[field_z].datatype = float_field_type;
+        ros_point_cloud.fields[field_z].count = 1;
+        ros_point_cloud.fields[field_radar_relative_radial_velocity].name = "radar_relative_radial_velocity";
+        ros_point_cloud.fields[field_radar_relative_radial_velocity].offset = offsetof(provizio_radar_point, radar_relative_radial_velocity_m_s);
+        ros_point_cloud.fields[field_radar_relative_radial_velocity].datatype = float_field_type;
+        ros_point_cloud.fields[field_radar_relative_radial_velocity].count = 1;
+        ros_point_cloud.fields[field_signal_to_noise_ratio].name = "signal_to_noise_ratio";
+        ros_point_cloud.fields[field_signal_to_noise_ratio].offset = offsetof(provizio_radar_point, signal_to_noise_ratio);
+        ros_point_cloud.fields[field_signal_to_noise_ratio].datatype = float_field_type;
+        ros_point_cloud.fields[field_signal_to_noise_ratio].count = 1;
+        ros_point_cloud.fields[field_ground_relative_radial_velocity].name = "ground_relative_radial_velocity";
+        ros_point_cloud.fields[field_ground_relative_radial_velocity].offset = offsetof(provizio_radar_point, ground_relative_radial_velocity_m_s);
+        ros_point_cloud.fields[field_ground_relative_radial_velocity].datatype = float_field_type;
+        ros_point_cloud.fields[field_ground_relative_radial_velocity].count = 1;
+        ros_point_cloud.is_bigendian = is_host_big_endian();
+        ros_point_cloud.point_step = sizeof(provizio_radar_point);
+        ros_point_cloud.row_step = sizeof(provizio_radar_point) * point_cloud->num_points_received;
+        ros_point_cloud.data.resize(ros_point_cloud.row_step);
+        std::memcpy(ros_point_cloud.data.data(), point_cloud->radar_points, ros_point_cloud.data.size());
+        ros_point_cloud.is_dense = true;
+
+        // Good to publish now
+        static_cast<ros::Publisher *>(context->user_data)->publish(ros_point_cloud);
+        points_sent += point_cloud->num_points_received;
+    }
+} // namespace
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "provizio_radar_api_ros_node");
+
+    ros::NodeHandle node;
+
+    // TODO: Support multiple radars use case, each publishing to their respective topics
+    ros::Publisher publisher = node.advertise<sensor_msgs::PointCloud2>(topic_name, 10);
+
+    // Initialize the Provizio Radar API Context
+    auto radar_api_context = std::make_unique<provizio_radar_point_cloud_api_context>();
+    provizio_radar_point_cloud_api_context_init(&point_cloud_callback, &publisher, radar_api_context.get());
+
+    // Open a live Provizio radar connection
+    provizio_radar_api_connection radar_api_connection;
+    std::memset(&radar_api_connection, 0, sizeof(&radar_api_connection));
+    auto status = provizio_open_radar_connection(0, receive_timeout_ns, 0, radar_api_context.get(), &radar_api_connection);
+    if (status != 0)
+    {
+        ROS_ERROR("provizio_open_radar_connection failed. Error code: %d", status);
+        return status;
+    }
+
+    ROS_INFO("provizio_radar_api_ros_node is running");
+
+    try
+    {
+        while (ros::ok())
+        {
+            // Receive the next radar packet if any (with timeout specified in receive_timeout_ns)
+            status = provizio_radar_api_receive_packet(&radar_api_connection);
+            if (status != 0 && status != PROVIZIO_E_TIMEOUT && status != PROVIZIO_E_SKIPPED)
+            {
+                if (status != EINTR)
+                {
+                    // Genuine error occured
+                    ROS_ERROR("provizio_radar_api_receive_packet failed. Error code: %d", status);
+                }
+                else
+                {
+                    // Interrupted by user, not really an error
+                }
+
+                break;
+            }
+
+            ros::spinOnce();
+        }
+    }
+    catch (...)
+    {
+        // Unexpected exception. Make sure to close the connection just in case.
+        provizio_close_radar_connection(&radar_api_connection);
+        throw;
+    }
+
+    if (status == PROVIZIO_E_TIMEOUT || status == PROVIZIO_E_SKIPPED || status == EINTR)
+    {
+        // Not really an error, they're all normal working statuses
+        status = 0;
+    }
+
+    ROS_INFO("provizio_radar_api_ros_node finished with status: %d. Point clouds sent: %" PRId64 ". Total points sent: %" PRId64 "\n", static_cast<int>(status), point_clouds_sent, points_sent);
+
+    provizio_close_radar_connection(&radar_api_connection);
+
+    return status;
+}


### PR DESCRIPTION
Basic ROS 1 Node added, as requested by customers. See https://provizio.atlassian.net/browse/APT-2065.

Tested using `tcpreplay` of a December capture from Hugh, and `rostopic echo` and working fine in ROS 1 Melodic (as used by customers).